### PR TITLE
Improve CPF generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _Read this in other languages: English, [Português(Brasil)](https://github.com/
 - [Installation](#installation)
   - [Generate CPF](#generate-cpf)
   - [Validate CPF](#validate-cpf)
-  - [Formate CPF](#formate-cpf)
+  - [Format CPF](#format-cpf)
 - [Contribute](#contribute)
 - [Donation](#donation)
 - [License](#license)
@@ -60,7 +60,7 @@ validateCPF('123.456.789-00')
 
 **Note:** characters like `.`, `-` and `space` are allowed.
 
-### Formate CPF
+### Format CPF
 
 ```javascript
 import { format as formatCPF } from 'gerador-validador-cpf'

--- a/src/js/CPF.ts
+++ b/src/js/CPF.ts
@@ -69,7 +69,7 @@ export const generate = (formatOption?: formatOptions): string => {
 
   // Generating the first CPF's 9 digits
   for (let i = 0; i < 9; ++i) {
-    firstNineDigits += String(Math.floor(Math.random() * 9))
+    firstNineDigits += String(Math.floor(Math.random() * 10))
   }
 
   const checker1 = calcFirstChecker(firstNineDigits)

--- a/src/js/CPF.ts
+++ b/src/js/CPF.ts
@@ -59,18 +59,32 @@ const formatCPF = (value: string, formatter?: formatOptions): string | void => {
   }
 }
 
+const allDigitsAreEqual = (digits: string) => {
+  for (let i = 1; i < digits.length; ++i) {
+    if (digits[i] !== digits[0]) {
+      return false
+    }
+  }
+
+  return true
+}
+
 /**
  * generate a valid CPF number
  * @param  {string} [formatOption]   Formatting option
  * @return {string}                  Valid and formatted CPF
  */
 export const generate = (formatOption?: formatOptions): string => {
-  let firstNineDigits = ''
+  let firstNineDigits: string
 
   // Generating the first CPF's 9 digits
-  for (let i = 0; i < 9; ++i) {
-    firstNineDigits += String(Math.floor(Math.random() * 10))
-  }
+  do {
+    firstNineDigits = ''
+
+    for (let i = 0; i < 9; ++i) {
+      firstNineDigits += String(Math.floor(Math.random() * 10))
+    }
+  } while (allDigitsAreEqual(firstNineDigits))
 
   const checker1 = calcFirstChecker(firstNineDigits)
   const generatedCPF =
@@ -99,10 +113,8 @@ export const validate = (value: string | number): boolean => {
   }
 
   // Checking if all digits are equal
-  for (let i = 0; i < 10; i++) {
-    if (`${firstNineDigits}${checker}` === Array(12).join(String(i))) {
-      return false
-    }
+  if (allDigitsAreEqual(`${firstNineDigits}${checker}`)) {
+    return false
   }
 
   const checker1 = calcFirstChecker(firstNineDigits)


### PR DESCRIPTION
<!--
Thanks for your contribution, it's so important.

It's an open source project, I share my free time here and in others [open source projects](https://tiagoporto.github.io).

Maybe I'll take time until review your pull request.

Don't be discouraged if this happens. One day I'll review it.

To help me, please provide a general summary of your changes.
-->

## Description
This PR contains three improvements, one commit for each.

**1. Fix typo in README.md**
This fixes a typo in the `README.md` file. The imperative tense of the verb _to format_ is _format_.

**2. Fix generator never generating a CPF with digit 9**
From the MDN web docs:

_The `Math.random()` function returns a floating-point, pseudo-random number in the range 0 to less than 1 (inclusive of 0, but not 1)_

As such, on [this line](https://github.com/tiagoporto/gerador-validador-cpf/blob/master/src/js/CPF.ts#L72), `Math.floor(Math.random() * 9)` will never return 9, since `Math.random() * 9` is always strictly less than 9.

This commit fixes this issue by changing the value 9 to 10.

**3. Fix generator possibly generating a CPF with all digits equal**
The CPF validator [checks if all digits are equal](https://github.com/tiagoporto/gerador-validador-cpf/blob/master/src/js/CPF.ts#L101) and returns `false` if that's the case. However, the generator do not treat this case and might possibly generate an invalid CPF, although the probability is quite small.

This commit simply regenerates the first 9 digits of the CPF if they happen to be all equal.