### PR TITLE
Changed wrong length cpf validation return, from error to false

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,10 +9,8 @@ export const generateFirstDigits = (): string => {
 
 export const hasCPFLength = (cpf: string): void | boolean => {
   if (cpf.length > 11) {
-    console.error('CPF number has more than 11 digits.')
     return false
   } else if (cpf.length < 11) {
-    console.error('CPF number has fewer than 11 digits.')
     return false
   }
 


### PR DESCRIPTION
Because of the console.error my app always broke when somebody entered a wrong length cpf, now it only returns false and I can deal with it on the app